### PR TITLE
Also update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "c821a6e124197eb56d907ccc2188eab1038fb919c914f47976e64dd8dbc855d1"
 
 [[package]]
 name = "mimxrt600-fcb"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bitfield",
 ]


### PR DESCRIPTION
After including Cargo.lock in the repository, we must also update Cargo.lock when the package's version changes, otherwise `cargo publish` will refuse to publish a new crate version.